### PR TITLE
Allow unicode characters in image file names.

### DIFF
--- a/ui/gui_draw.py
+++ b/ui/gui_draw.py
@@ -51,7 +51,7 @@ class GUIDraw(QWidget):
         self.update()
 
     def init_result(self, image_file):
-        self.read_image(image_file)  # read an image
+        self.read_image(image_file.encode('utf-8'))  # read an image
         self.reset()
 
     def get_batches(self, img_dir):
@@ -223,7 +223,7 @@ class GUIDraw(QWidget):
         self.eraseMode = not self.eraseMode
 
     def load_image(self):
-        img_path = str(QFileDialog.getOpenFileName(self, 'load an input image'))
+        img_path = unicode(QFileDialog.getOpenFileName(self, 'load an input image'))
         self.init_result(img_path)
 
     def save_result(self):


### PR DESCRIPTION
I was finding that the interactive tool wasn't letting me select filenames with unicode characters.
This is because the "str" type in Python is ASCII by default, and needs to be explicitly encoded as UTF-8.